### PR TITLE
Added support for indent option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,14 @@ module.exports = function(grunt) {
         files: {
           'tmp/custom_options': 'test/fixtures/file2'
         }
+      },
+      custom_indent_options: {
+        options: {
+          indent: true
+        },
+        files: {
+          'tmp/custom_indent_options': 'test/fixtures/file3'
+        }
       }
     },
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ This string will be appended to the end of the output. It is processed using [gr
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
+#### indent
+Type: `Boolean`
+Default: false
+
+If true, any whitespace preceding the @import statement will be preserved and the all of the imported content will be automatically indented. 
+
 ### Usage Examples
 
 **To include a file into another file add `@import "path/to/another/file";` at any point inside your importing/source file.**

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "1.0.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-internal": "~0.4.2"
   },

--- a/test/expected/custom_indent_options
+++ b/test/expected/custom_indent_options
@@ -1,0 +1,3 @@
+    file1
+    file2
+file3

--- a/test/fixtures/file3
+++ b/test/fixtures/file3
@@ -1,0 +1,2 @@
+    @import 'file2';
+file3

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -25,5 +25,14 @@ exports.import = {
     test.equal(actual, expected, 'should utilize custom banner, footer and separator.');
 
     test.done();
+  },
+  custom_indent_options: function(test) {
+    test.expect(1);
+  
+    var actual = getNormalizedFile('tmp/custom_indent_options');
+    var expected = getNormalizedFile('test/expected/custom_indent_options');
+    test.equal(actual, expected, 'should indent imported content.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
Indent option indents the imported content based on the white space before the @import statement. This is useful e.g. when writing API Blueprint definitions where the examples and schema definitions must be properly indented.